### PR TITLE
Adds the ability to find out what is wrong with resolution checks

### DIFF
--- a/SRC/LibVideoTester/Models/VideoMetaData.cs
+++ b/SRC/LibVideoTester/Models/VideoMetaData.cs
@@ -52,11 +52,8 @@ namespace LibVideoTester.Models
 
         public bool ResolutionValid(Configuration c, out ResolutionValidationFailureReason failureReason)
         {
-            ResolutionValidationFailureReason AppendIfNotNone(ResolutionValidationFailureReason input, ResolutionValidationFailureReason toAppend)
-            {
-                return input == ResolutionValidationFailureReason.None ? toAppend : input | toAppend;
-            }
-
+            ResolutionValidationFailureReason AppendIfNotNone(ResolutionValidationFailureReason input, ResolutionValidationFailureReason toAppend) => input == ResolutionValidationFailureReason.None ? toAppend : input | toAppend;
+            
             failureReason = ResolutionValidationFailureReason.None;
             if (IsHap())
             {

--- a/SRC/LibVideoTester/Providers/FFProbeMetaDataProvider.cs
+++ b/SRC/LibVideoTester/Providers/FFProbeMetaDataProvider.cs
@@ -2,31 +2,33 @@
 using System.Diagnostics;
 using System.Threading.Tasks;
 
-namespace LibVideoTester.Providers;
-
-//NOTE THIS CAN"T BE UNIT TESTED AS IT TESTS SOMETHING OUTSIDE OF OF THE PROJECT    
-public class FFProbeMetaDataProvider : IVideoMetaDataProvider
+namespace LibVideoTester.Providers
 {
-    private string _executablePath;
-    public FFProbeMetaDataProvider(string executablePath = "ffprobe") {
-        _executablePath = executablePath;
-    }
-
-    public async Task<string> GetMetaDataFromFile(string filename)
+    //NOTE THIS CAN"T BE UNIT TESTED AS IT TESTS SOMETHING OUTSIDE OF OF THE PROJECT    
+    public class FFProbeMetaDataProvider : IVideoMetaDataProvider
     {
-        var process = new Process
+        private string _executablePath;
+        public FFProbeMetaDataProvider(string executablePath = "ffprobe")
         {
-            StartInfo = { FileName = _executablePath,
+            _executablePath = executablePath;
+        }
+
+        public async Task<string> GetMetaDataFromFile(string filename)
+        {
+            var process = new Process
+            {
+                StartInfo = { FileName = _executablePath,
             Arguments = $"-v error -select_streams v:0 -show_entries stream=width,height,duration,bit_rate,r_frame_rate,codec_name -of default=noprint_wrappers=1 \"{filename}\"",
             UseShellExecute = false,
             RedirectStandardOutput = true,
             CreateNoWindow = true
             }
-        };
-        await Task.Run(() => process.Start());
-        string result =  await process.StandardOutput.ReadToEndAsync();
-        return result;
+            };
+            await Task.Run(() => process.Start());
+            string result = await process.StandardOutput.ReadToEndAsync();
+            return result;
 
+        }
     }
-}
 
+}

--- a/SRC/VideoTesterTests/ValidateVideoInfoTests.cs
+++ b/SRC/VideoTesterTests/ValidateVideoInfoTests.cs
@@ -11,7 +11,7 @@ namespace VideoTesterTests
         public void Setup()
         {
             string[] validCodecs = new string[] { "hap", "h264", "hevc", "hapa", };
-            c = new Configuration("Sample Config",validCodecs, 500, 500, new int[] { 30, 60 }, 1024);
+            c = new Configuration("Sample Config", validCodecs, 500, 500, new int[] { 30, 60 }, 1024);
         }
 
         [Test]
@@ -35,6 +35,31 @@ namespace VideoTesterTests
             VideoMetaData v = new VideoMetaData("hap", 123, 400, 30, 1024);
             Assert.IsFalse(v.ResolutionValid(c));
         }
+
+        [Test]
+        public void shouldReturnFailureReasonHapNotDivisbleByFour()
+        {
+            VideoMetaData v = new VideoMetaData("hap", 123, 127, 30, 1024);
+            VideoMetaData.ResolutionValidationFailureReason failureReason;
+            Assert.IsFalse(v.ResolutionValid(c, out failureReason));
+            Assert.AreEqual(VideoMetaData.ResolutionValidationFailureReason.NotDivisbleByFourWidth | VideoMetaData.ResolutionValidationFailureReason.NotDivisbleByFourHeight, failureReason);
+        }
+
+        [Test]
+        public void shouldReturnFailureReasonHapNotDivisbleByFourAndWidthAndHeightTooBig()
+        {
+            VideoMetaData v = new VideoMetaData("hap",999999, 99999, 30, 1024);
+            VideoMetaData.ResolutionValidationFailureReason failureReason;
+            Assert.IsFalse(v.ResolutionValid(c, out failureReason));
+            Assert.AreEqual(VideoMetaData.ResolutionValidationFailureReason.HeightTooLarge | VideoMetaData.ResolutionValidationFailureReason.WidthTooLarge | VideoMetaData.ResolutionValidationFailureReason.NotDivisbleByFourWidth | VideoMetaData.ResolutionValidationFailureReason.NotDivisbleByFourHeight, failureReason);
+        }
+
+        /*[Test]
+        public void shouldReturnFailureReasonHapNotDivisbleByFourAndTooLarge()
+        {
+            VideoMetaData v = new VideoMetaData("hap", 123, 400, 30, 1024);
+            Assert.IsFalse(v.ResolutionValid(c));
+        }*/
 
         [Test]
         public void shouldHaveValidConfig()

--- a/SRC/VideoTesterTests/ValidateVideoInfoTests.cs
+++ b/SRC/VideoTesterTests/ValidateVideoInfoTests.cs
@@ -54,13 +54,6 @@ namespace VideoTesterTests
             Assert.AreEqual(VideoMetaData.ResolutionValidationFailureReason.HeightTooLarge | VideoMetaData.ResolutionValidationFailureReason.WidthTooLarge | VideoMetaData.ResolutionValidationFailureReason.NotDivisbleByFourWidth | VideoMetaData.ResolutionValidationFailureReason.NotDivisbleByFourHeight, failureReason);
         }
 
-        /*[Test]
-        public void shouldReturnFailureReasonHapNotDivisbleByFourAndTooLarge()
-        {
-            VideoMetaData v = new VideoMetaData("hap", 123, 400, 30, 1024);
-            Assert.IsFalse(v.ResolutionValid(c));
-        }*/
-
         [Test]
         public void shouldHaveValidConfig()
         {


### PR DESCRIPTION
- Fixes a bug where namespace was represented in c# 8.0 style, not currently supported
- Adds unit tests and a feature extension which returns the reasons for the resolution check failing, so we can provide more useful feedback to users.